### PR TITLE
添加检测模型选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ For instance:
 face-mask /path/to/face/picture --blue
 ```
 
+In addition, you can specify different detection models by `--model` option:
+- `hog` is less accurate but faster on CPUs.
+- `cnn` is a more accurate deep-learning model which is GPU/CUDA accelerated (if available).
+
+```bash
+face-mask /path/to/face/picture --model cnn
+```
+
 ## Effects
 ### One person wears a mask
 ![](images/face-mask-single.jpg)

--- a/face_mask/__main__.py
+++ b/face_mask/__main__.py
@@ -18,6 +18,7 @@ def cli():
     parser = argparse.ArgumentParser(description='Wear a face mask in the given picture.')
     parser.add_argument('pic_path', help='Picture path.')
     parser.add_argument('--show', action='store_true', help='Whether show picture with mask or not.')
+    parser.add_argument('--model', default='hog', choices=['hog', 'cnn'], help='Which face detection model to use.')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--black', action='store_true', help='Wear black mask')
     group.add_argument('--blue', action='store_true', help='Wear blue mask')
@@ -38,16 +39,17 @@ def cli():
     else:
         mask_path = DEFAULT_IMAGE_PATH
 
-    FaceMasker(pic_path, mask_path, args.show).mask()
+    FaceMasker(pic_path, mask_path, args.show, args.model).mask()
 
 
 class FaceMasker:
     KEY_FACIAL_FEATURES = ('nose_bridge', 'chin')
 
-    def __init__(self, face_path, mask_path, show=False):
+    def __init__(self, face_path, mask_path, show=False, model='hog'):
         self.face_path = face_path
         self.mask_path = mask_path
         self.show = show
+        self.model = model
         self._face_img: ImageFile = None
         self._mask_img: ImageFile = None
 
@@ -55,7 +57,8 @@ class FaceMasker:
         import face_recognition
 
         face_image_np = face_recognition.load_image_file(self.face_path)
-        face_landmarks = face_recognition.face_landmarks(face_image_np)
+        face_locations = face_recognition.face_locations(face_image_np, model=self.model)
+        face_landmarks = face_recognition.face_landmarks(face_image_np, face_locations)
         self._face_img = Image.fromarray(face_image_np)
         self._mask_img = Image.open(self.mask_path)
 

--- a/face_mask/__main__.py
+++ b/face_mask/__main__.py
@@ -4,7 +4,7 @@ import argparse
 import numpy as np
 from PIL import Image, ImageFile
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 
 IMAGE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'images')


### PR DESCRIPTION
face_recognition 支持两种检测模型：`cnn` 和 `hog`，而两种模型在速度和检测效果上存在一些差异，因此添加 `--model` 选项以提供检测模型的切换。
如原图：
![image](https://user-images.githubusercontent.com/6391488/73596838-0bc7a900-4561-11ea-8f2a-6214ac316be7.png)

使用 `hog`（默认）的效果：
![image](https://user-images.githubusercontent.com/6391488/73596859-374a9380-4561-11ea-9a3f-eb7254620bc5.png)

而使用 `cnn` 模型的效果：
![image](https://user-images.githubusercontent.com/6391488/73596874-64974180-4561-11ea-8407-ae16e6b8acb9.png)

从结果来看 `cnn` 比 `hog` 能够相对检测出更多的人脸，但是不能完全替代（有一些缺陷），因此添加此选项是很有意义的。